### PR TITLE
Mccalluc/purge google docs refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.2 - In progress
+- Enforce assay types; Remove references to google sheets.
 
 ## v0.0.1 - 2020-05-03
 ### Added

--- a/data/definitions.yaml
+++ b/data/definitions.yaml
@@ -281,11 +281,10 @@ fields:
     enum: null
     required: false
   data_types:
-    description: 'TODO: An array of data/assay types contained in the Dataset.  Allowable
-      values here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+    description: 'TODO: An array of data/assay types contained in the Dataset.'
     entity_types:
     - dataset
-    enum: null
+    enum: assay_types
     required: false
   description:
     description: A description of the Entity, hand entered into the UI
@@ -398,8 +397,7 @@ fields:
     enum: null
     required: Depends on entity type
   organ:
-    description: 'The organ type when specimen_type == organ.  Allowable values here:
-      https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+    description: The organ type when specimen_type == organ.
     entity_types:
     - sample
     enum: organ_types
@@ -467,8 +465,7 @@ fields:
     enum: null
     required: Depends on entity type
   specimen_type:
-    description: 'For Sample entities, the type of tissue specimen.  Allowable values
-      here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+    description: For Sample entities, the type of tissue specimen.
     entity_types:
     - sample
     enum: tissue_sample_types
@@ -481,7 +478,7 @@ fields:
     enum: null
     required: false
   status:
-    description: 'The status of a Dataset. Allowable values listed here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+    description: The status of a Dataset.
     entity_types:
     - dataset
     enum: dataset_status_types

--- a/data/definitions/fields.tsv
+++ b/data/definitions/fields.tsv
@@ -7,7 +7,7 @@ Entity.provenance_create_timestamp	create_timestamp	Yes	Donor, Sample, Dataset		
 Metadata.rui_location	rui_location	No	Sample		Location information of where the tissue sample came from in the organ that the tissue was sourced from.  Specified in JSON, as outputed from the RUI tool.
 Metadata.lab_tissue_id	lab_tissue_sample_id	Depends on entity type	Sample		An id specific to the lab where the tissue was processed.
 Entity.uuid	uuid	Yes	Donor, Sample, Dataset		The HuBMAP auto-generated UUID for the Entity
-Metadata.data_types	data_types	No	Dataset		TODO: An array of data/assay types contained in the Dataset.  Allowable values here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit
+Metadata.data_types	data_types	No	Dataset	assay_types	TODO: An array of data/assay types contained in the Dataset.
 Metadata.description	description	No	Donor, Sample, Dataset		A description of the Entity, hand entered into the UI
 Metadata.ingest_metadata	metadata	No	Donor, Sample, Dataset		Metadata associated with the Entity. Formated in JSON. Donor metadata is transformed from files uploaded into the Ingest UI.  Sample metadata will be transformed from files uploaded into the Ingest UI.  Dataset metadata will be transformed from the HIVE specified .tsv file provided with data uploads and/or extraction from data or metadata files provided in the data upload.
 Metadata.files	files	No	Dataset		An array of information about the files contained in the dataset.
@@ -16,7 +16,7 @@ Metadata.lab_donor_id	lab_donor_id	Depends on entity type	Donor		An donor id spe
 Metadata.label	lab_name	No	Donor		A lab specific label/name assigned to a donor by the lab during registration of the donor.
 Metadata.metadatas	portal_metadata_upload_files	No	Donor, Sample		An array of information about metadata files uploaded via the Tissue Registration UI
 Metadata.name	name	Depends on entity type	Dataset		The name of a dataset as entered into the Ingest UI
-Metadata.organ	organ	No	Sample	organ_types	The organ type when specimen_type == organ.  Allowable values here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit
+Metadata.organ	organ	No	Sample	organ_types	The organ type when specimen_type == organ.
 Metadata.organ_other	organ_other	No	Sample		If organ type == other, the organ name is specified in this field
 Metadata.phi	contains_human_genetic_sequences	Yes	Dataset		true if the data contains human gene sequence information, false otherwise
 Metadata.protocol	protocol_url	Just one of these two	Donor, Sample		The url to the protocols.io instance describing donor selection criteria, tissue procurement protocols and or data generation/derivation details.
@@ -26,9 +26,9 @@ Metadata.provenance_group_uuid	group_uuid	Yes	Donor, Sample, Dataset		A UUID ass
 Metadata.provenance_modified_timestamp	last_modified_timestamp	Yes	Donor, Sample, Dataset		The date/time when the entity was last updatedl
 Metadata.provenance_user_displayname	created_by_user_displayname	Yes	Donor, Sample, Dataset		The name of the person who registered/created the Entity.
 Metadata.provenance_user_email	created_by_user_email	Yes	Donor, Sample, Dataset		The email address of the person who registerd/created the Entity.
-Metadata.specimen_type	specimen_type	Yes	Sample	tissue_sample_types	For Sample entities, the type of tissue specimen.  Allowable values here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit
+Metadata.specimen_type	specimen_type	Yes	Sample	tissue_sample_types	For Sample entities, the type of tissue specimen.
 Metadata.specimen_type_other	specimen_type_other	No	Sample		If specimen_type == other, the specimen type name is specified in this field
-Metadata.status	status	Depends on entity type	Dataset	dataset_status_types	The status of a Dataset. Allowable values listed here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit
+Metadata.status	status	Depends on entity type	Dataset	dataset_status_types	The status of a Dataset.
 Metadata.visit	visit	No	Sample		The clinical visit specifier of when a piece of tissue was procured.  This is hand entered via the Tissue Registration UI at the time of tissue registration.
 	donor	Depends on entity type	Sample, Dataset		The ancestor Donor at the top of the provenance chain for the Entity.  This contains, in JSON, the full Entity information for the Donor.
 	origin_sample	Depends on entity type	Sample, Dataset		The tissue sample directly below Donor (should usually be an organ) at the top of the provenance chain for the Entity. This conntains, in JSON, the full Entity information for the Sample.

--- a/data/schemas/dataset.schema.yaml
+++ b/data/schemas/dataset.schema.yaml
@@ -18,8 +18,30 @@ properties:
   creation_action:
     description: The action that created this this Entity
   data_types:
-    description: 'TODO: An array of data/assay types contained in the Dataset.  Allowable
-      values here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+    description: 'TODO: An array of data/assay types contained in the Dataset.'
+    enum:
+    - AF
+    - ATACseq-bulk
+    - CODEX
+    - IMC
+    - LC-MS-untargeted
+    - MALDI-IMS-neg
+    - MALDI-IMS-pos
+    - MxIF
+    - PAS
+    - SNAREseq
+    - TMT-LC-MS
+    - Targeted-Shotgun-LC-MS
+    - WGS
+    - bulk-RNA
+    - codex_cytokit
+    - salmon_rnaseq_10x
+    - scRNA-Seq-10x
+    - sciATACseq
+    - sciRNAseq
+    - seqFish
+    - snATACseq
+    - snRNAseq
   descendant_ids:
     description: TODO
   descendants:
@@ -172,8 +194,7 @@ properties:
           with data uploads and/or extraction from data or metadata files provided
           in the data upload.
       organ:
-        description: 'The organ type when specimen_type == organ.  Allowable values
-          here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+        description: The organ type when specimen_type == organ.
         enum:
         - BL
         - BR
@@ -236,8 +257,7 @@ properties:
           the organ that the tissue was sourced from.  Specified in JSON, as outputed
           from the RUI tool.
       specimen_type:
-        description: 'For Sample entities, the type of tissue specimen.  Allowable
-          values here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+        description: For Sample entities, the type of tissue specimen.
         enum:
         - atacseq
         - biopsy
@@ -352,8 +372,7 @@ properties:
             with data uploads and/or extraction from data or metadata files provided
             in the data upload.
         organ:
-          description: 'The organ type when specimen_type == organ.  Allowable values
-            here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+          description: The organ type when specimen_type == organ.
           enum:
           - BL
           - BR
@@ -417,8 +436,7 @@ properties:
             the organ that the tissue was sourced from.  Specified in JSON, as outputed
             from the RUI tool.
         specimen_type:
-          description: 'For Sample entities, the type of tissue specimen.  Allowable
-            values here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+          description: For Sample entities, the type of tissue specimen.
           enum:
           - atacseq
           - biopsy
@@ -487,7 +505,7 @@ properties:
       type: object
     type: array
   status:
-    description: 'The status of a Dataset. Allowable values listed here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+    description: The status of a Dataset.
     enum:
     - DEPRECATED
     - ERROR

--- a/data/schemas/sample.schema.yaml
+++ b/data/schemas/sample.schema.yaml
@@ -121,8 +121,7 @@ properties:
       be transformed from the HIVE specified .tsv file provided with data uploads
       and/or extraction from data or metadata files provided in the data upload.
   organ:
-    description: 'The organ type when specimen_type == organ.  Allowable values here:
-      https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+    description: The organ type when specimen_type == organ.
     enum:
     - BL
     - BR
@@ -211,8 +210,7 @@ properties:
           with data uploads and/or extraction from data or metadata files provided
           in the data upload.
       organ:
-        description: 'The organ type when specimen_type == organ.  Allowable values
-          here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+        description: The organ type when specimen_type == organ.
         enum:
         - BL
         - BR
@@ -275,8 +273,7 @@ properties:
           the organ that the tissue was sourced from.  Specified in JSON, as outputed
           from the RUI tool.
       specimen_type:
-        description: 'For Sample entities, the type of tissue specimen.  Allowable
-          values here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+        description: For Sample entities, the type of tissue specimen.
         enum:
         - atacseq
         - biopsy
@@ -359,8 +356,7 @@ properties:
       organ that the tissue was sourced from.  Specified in JSON, as outputed from
       the RUI tool.
   specimen_type:
-    description: 'For Sample entities, the type of tissue specimen.  Allowable values
-      here: https://docs.google.com/spreadsheets/d/1L8mfs767Z5ZGnZ92UJySlHxprraSariH1dU45g6jphE/edit'
+    description: For Sample entities, the type of tissue specimen.
     enum:
     - atacseq
     - biopsy

--- a/examples/dataset.json
+++ b/examples/dataset.json
@@ -85,7 +85,7 @@
   "create_timestamp": 1584312481755,
   "created_by_user_displayname": "Dana L Jackson",
   "created_by_user_email": "danaj77@washington.edu",
-  "data_types": "['dt_scatacdeq']",
+  "data_types": "snATACseq",
   "descendant_ids": [],
   "descendants": [],
   "description": "Left ventricle ATAC-seq data\n8 sequences",


### PR DESCRIPTION
Following up from Slack: Checking in the derived data isn't a best-practice... but sometimes changes in the derived data a surprise, so it also functions as a test. In this case, the real edits are in `fields.tsv`, and everything else is derived from that. One consequence is that in the portal we'll start getting errors about bad assay types because the API is giving us strings that don't match the enumeration in the spec.