### PR TITLE
Re

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.0.3 - In progress
 - Add Pyramid type.
 - Clean up assay names.
+- Add new assay_type and remove portal_uploaded_protocol_files.
 
 ## v0.0.2 - 2020-06-29
 - Add lightsheet.

--- a/data/definitions.yaml
+++ b/data/definitions.yaml
@@ -44,6 +44,8 @@ enums:
       description: sciRNA-seq
     seqFish:
       description: seqFish
+    seqFish_lab_processed:
+      description: processed seqFISH data [processed at source lab]
     snATACseq:
       description: snATAC-seq
     snRNAseq:
@@ -437,14 +439,6 @@ fields:
     - sample
     enum: null
     required: false
-  portal_uploaded_protocol_files:
-    description: An array of information about files uploaded through the Donor/Tissue
-      Registration UI donor selection criteria or tissue procurement protocols.
-    entity_types:
-    - donor
-    - sample
-    enum: null
-    required: Just one of these two
   protocol_url:
     description: The url to the protocols.io instance describing donor selection criteria,
       tissue procurement protocols and or data generation/derivation details.

--- a/data/definitions/enums/assay_types.tsv
+++ b/data/definitions/enums/assay_types.tsv
@@ -17,9 +17,11 @@ scRNA-Seq-10x	scRNA-seq (10x Genomics)
 sciATACseq	sciATAC-seq
 sciRNAseq	sciRNA-seq
 seqFish	seqFish
+seqFish_lab_processed	processed seqFISH data [processed at source lab]
 snATACseq	snATAC-seq
 snRNAseq	snRNA-seq
 codex_cytokit	CODEX [Cytokit + SPRM]
 salmon_rnaseq_10x	scRNA-seq (10x Genomics) [Salmon]
 Lightsheet	Lightsheet Microscopy
 image_pyramid	Image Pyramid
+

--- a/data/definitions/fields.tsv
+++ b/data/definitions/fields.tsv
@@ -20,7 +20,6 @@ Metadata.organ	organ	No	Sample	organ_types	The organ type when specimen_type == 
 Metadata.organ_other	organ_other	No	Sample		If organ type == other, the organ name is specified in this field
 Metadata.phi	contains_human_genetic_sequences	Yes	Dataset		true if the data contains human gene sequence information, false otherwise
 Metadata.protocol	protocol_url	Just one of these two	Donor, Sample		The url to the protocols.io instance describing donor selection criteria, tissue procurement protocols and or data generation/derivation details.
-Metadata.protocols	portal_uploaded_protocol_files	Just one of these two	Donor, Sample		An array of information about files uploaded through the Donor/Tissue Registration UI donor selection criteria or tissue procurement protocols.
 Metadata.provenance_group_name	group_name	Yes	Donor, Sample, Dataset		The name of the lab/TMC/TTD/RTI where the Entity was registered.
 Metadata.provenance_group_uuid	group_uuid	Yes	Donor, Sample, Dataset		A UUID associated with the lab/TMC/TTD/RTI where the Entity was registered.
 Metadata.provenance_modified_timestamp	last_modified_timestamp	Yes	Donor, Sample, Dataset		The date/time when the entity was last updatedl

--- a/data/schemas/dataset.schema.yaml
+++ b/data/schemas/dataset.schema.yaml
@@ -42,6 +42,7 @@ properties:
     - sciATACseq
     - sciRNAseq
     - seqFish
+    - seqFish_lab_processed
     - snATACseq
     - snRNAseq
   descendant_ids:
@@ -107,9 +108,6 @@ properties:
       portal_uploaded_image_files:
         description: An array of information about image files uploaded during donor
           or tissue registration via the Tissue Registration UI
-      portal_uploaded_protocol_files:
-        description: An array of information about files uploaded through the Donor/Tissue
-          Registration UI donor selection criteria or tissue procurement protocols.
       protocol_url:
         description: The url to the protocols.io instance describing donor selection
           criteria, tissue procurement protocols and or data generation/derivation
@@ -247,9 +245,6 @@ properties:
       portal_uploaded_image_files:
         description: An array of information about image files uploaded during donor
           or tissue registration via the Tissue Registration UI
-      portal_uploaded_protocol_files:
-        description: An array of information about files uploaded through the Donor/Tissue
-          Registration UI donor selection criteria or tissue procurement protocols.
       protocol_url:
         description: The url to the protocols.io instance describing donor selection
           criteria, tissue procurement protocols and or data generation/derivation
@@ -426,9 +421,6 @@ properties:
         portal_uploaded_image_files:
           description: An array of information about image files uploaded during donor
             or tissue registration via the Tissue Registration UI
-        portal_uploaded_protocol_files:
-          description: An array of information about files uploaded through the Donor/Tissue
-            Registration UI donor selection criteria or tissue procurement protocols.
         protocol_url:
           description: The url to the protocols.io instance describing donor selection
             criteria, tissue procurement protocols and or data generation/derivation

--- a/data/schemas/donor.schema.yaml
+++ b/data/schemas/donor.schema.yaml
@@ -57,9 +57,6 @@ properties:
   portal_uploaded_image_files:
     description: An array of information about image files uploaded during donor or
       tissue registration via the Tissue Registration UI
-  portal_uploaded_protocol_files:
-    description: An array of information about files uploaded through the Donor/Tissue
-      Registration UI donor selection criteria or tissue procurement protocols.
   protocol_url:
     description: The url to the protocols.io instance describing donor selection criteria,
       tissue procurement protocols and or data generation/derivation details.

--- a/data/schemas/sample.schema.yaml
+++ b/data/schemas/sample.schema.yaml
@@ -77,9 +77,6 @@ properties:
       portal_uploaded_image_files:
         description: An array of information about image files uploaded during donor
           or tissue registration via the Tissue Registration UI
-      portal_uploaded_protocol_files:
-        description: An array of information about files uploaded through the Donor/Tissue
-          Registration UI donor selection criteria or tissue procurement protocols.
       protocol_url:
         description: The url to the protocols.io instance describing donor selection
           criteria, tissue procurement protocols and or data generation/derivation
@@ -261,9 +258,6 @@ properties:
       portal_uploaded_image_files:
         description: An array of information about image files uploaded during donor
           or tissue registration via the Tissue Registration UI
-      portal_uploaded_protocol_files:
-        description: An array of information about files uploaded through the Donor/Tissue
-          Registration UI donor selection criteria or tissue procurement protocols.
       protocol_url:
         description: The url to the protocols.io instance describing donor selection
           criteria, tissue procurement protocols and or data generation/derivation
@@ -345,9 +339,6 @@ properties:
   portal_uploaded_image_files:
     description: An array of information about image files uploaded during donor or
       tissue registration via the Tissue Registration UI
-  portal_uploaded_protocol_files:
-    description: An array of information about files uploaded through the Donor/Tissue
-      Registration UI donor selection criteria or tissue procurement protocols.
   protocol_url:
     description: The url to the protocols.io instance describing donor selection criteria,
       tissue procurement protocols and or data generation/derivation details.

--- a/examples/dataset.json
+++ b/examples/dataset.json
@@ -20,12 +20,6 @@
       "last_modified_timestamp": 1576876531656,
       "portal_metadata_upload_files": [],
       "portal_uploaded_image_files": [],
-      "portal_uploaded_protocol_files": [
-        {
-          "protocol_doi": "",
-          "protocol_file": "/hive/hubmap/lz/tissue-reg-data/def5fd76-ed43-11e8-b56a-0e8017bdda58/018792bcfc178ae285dca044d2b97239/hubmap_protocol_tissue_collection.pdf"
-        }
-      ],
       "specimen_type": "organ_piece",
       "uuid": "c1f0cc0152231ce6276475b3ea800aab"
     },
@@ -50,12 +44,6 @@
         }
       ],
       "portal_uploaded_image_files": [],
-      "portal_uploaded_protocol_files": [
-        {
-          "protocol_file": "/hive/hubmap/lz/tissue-reg-data/def5fd76-ed43-11e8-b56a-0e8017bdda58/9513fcfa45c1f939ab0eb0ae18266762/hubmap_protocol_tissue_collection.pdf",
-          "protocol_url": ""
-        }
-      ],
       "specimen_type": "organ",
       "uuid": "36d34bbfc026545aeac0c5acd47f3f91"
     },
@@ -128,12 +116,6 @@
     "lab_tissue_sample_id": "W101 spleen, central",
     "last_modified_timestamp": 1571148594392,
     "organ": "SP",
-    "portal_uploaded_protocol_files": [
-      {
-        "protocol_file": "/hive/hubmap/lz/tissue-reg-data/def5fd76-ed43-11e8-b56a-0e8017bdda58/79c45e0a679d1ef5aaa2e4fc8395d5a3/hubmap_protocol_tissue_collection.pdf",
-        "protocol_url": ""
-      }
-    ],
     "specimen_type": "organ",
     "uuid": "d8204a70984bab4669121de9b9388e1d"
   },
@@ -152,12 +134,6 @@
       "last_modified_timestamp": 1576876531656,
       "portal_metadata_upload_files": [],
       "portal_uploaded_image_files": [],
-      "portal_uploaded_protocol_files": [
-        {
-          "protocol_doi": "",
-          "protocol_file": "/hive/hubmap/lz/tissue-reg-data/def5fd76-ed43-11e8-b56a-0e8017bdda58/018792bcfc178ae285dca044d2b97239/hubmap_protocol_tissue_collection.pdf"
-        }
-      ],
       "specimen_type": "organ_piece",
       "uuid": "c1f0cc0152231ce6276475b3ea800aab"
     }

--- a/examples/sample.json
+++ b/examples/sample.json
@@ -17,12 +17,6 @@
       "group_uuid": "def5fd76-ed43-11e8-b56a-0e8017bdda58",
       "hubmap_display_id": "STAN0003-SI-1",
       "last_modified_timestamp": 1572559158389,
-      "portal_uploaded_protocol_files": [
-        {
-          "protocol_file": "/hive/hubmap/lz/tissue-reg-data/def5fd76-ed43-11e8-b56a-0e8017bdda58/89f5fe6590b5dbbd7f2e99c1038f02f5/hubmap_protocol_tissue_collection.pdf",
-          "protocol_url": ""
-        }
-      ],
       "specimen_type": "organ_piece",
       "uuid": "bf1db74f40506e87055eda7b84a79174"
     },
@@ -46,12 +40,6 @@
         }
       ],
       "portal_uploaded_image_files": [],
-      "portal_uploaded_protocol_files": [
-        {
-          "protocol_file": "/hive/hubmap/lz/tissue-reg-data/def5fd76-ed43-11e8-b56a-0e8017bdda58/617ba59425d7c2b0e14224263cdd5fb8/hubmap_protocol_tissue_collection.pdf",
-          "protocol_url": ""
-        }
-      ],
       "specimen_type": "organ",
       "uuid": "eed96170f42554db84d97d1652bb23ef"
     },
@@ -132,21 +120,9 @@
       }
     ],
     "portal_uploaded_image_files": [],
-    "portal_uploaded_protocol_files": [
-      {
-        "protocol_file": "/hive/hubmap/lz/tissue-reg-data/def5fd76-ed43-11e8-b56a-0e8017bdda58/617ba59425d7c2b0e14224263cdd5fb8/hubmap_protocol_tissue_collection.pdf",
-        "protocol_url": ""
-      }
-    ],
     "specimen_type": "organ",
     "uuid": "eed96170f42554db84d97d1652bb23ef"
   },
-  "portal_uploaded_protocol_files": [
-    {
-      "protocol_file": "/hive/hubmap/lz/tissue-reg-data/def5fd76-ed43-11e8-b56a-0e8017bdda58/3402e7835fdf466fb47d99cb04c882c9/hubmap_protocol_tissue_collection.pdf",
-      "protocol_url": ""
-    }
-  ],
   "specimen_type": "flash_frozen_liquid_nitrogen",
   "uuid": "2b5b0b33efe54dfe6c4de631f7be13a2"
 }


### PR DESCRIPTION
 - added assay_type code, seqFISH_lab_processed, for processed (derived dataset) seqFISH data coming from a TMC
 - removed portal_uploaded_protocol_files attributes to default index, any protocol information will come from the protocol_url attribute which contains a protocols.io DOI URL.