### PR TITLE
Add human-readable labels for unmapped codes coming from pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Status descriptions.
 - Add data_access_level.
 - Update 'seqFISH [Lab Processed]'.
+- Add assay-type codes seen on production.
 
 ## v0.0.2 - 2020-06-29
 - Add lightsheet.

--- a/data/definitions.yaml
+++ b/data/definitions.yaml
@@ -36,14 +36,22 @@ enums:
       description: Image Pyramid
     salmon_rnaseq_10x:
       description: scRNA-seq (10x Genomics) [Salmon]
+    salmon_rnaseq_bulk:
+      description: Bulk RNA-seq [Salmon]
+    salmon_rnaseq_sciseq:
+      description: sciRNA-seq [Salmon]
+    salmon_rnaseq_snareseq:
+      description: scRNA-seq (SNARE-seq) [Salmon]
     scRNA-Seq-10x:
       description: scRNA-seq (10x Genomics)
+    sc_atac_seq_snare:
+      description: scATAC-seq (SNARE-seq) [SnapATAC]
     sciATACseq:
       description: sciATAC-seq
     sciRNAseq:
       description: sciRNA-seq
     seqFish:
-      description: seqFish
+      description: seqFISH
     seqFish_lab_processed:
       description: seqFISH [Lab Processed]
     snATACseq:

--- a/data/definitions/enums/assay_types.yaml
+++ b/data/definitions/enums/assay_types.yaml
@@ -34,6 +34,14 @@ image_pyramid:
     description: Image Pyramid
 salmon_rnaseq_10x:
     description: scRNA-seq (10x Genomics) [Salmon]
+salmon_rnaseq_bulk:
+    description: Bulk RNA-seq [Salmon]
+salmon_rnaseq_sciseq:
+    description: sciRNA-seq [Salmon]
+salmon_rnaseq_snareseq:
+    description: scRNA-seq (SNARE-seq) [Salmon]
+sc_atac_seq_snare:
+    description: scATAC-seq (SNARE-seq) [SnapATAC]
 scRNA-Seq-10x:
     description: scRNA-seq (10x Genomics)
 sciATACseq:
@@ -41,7 +49,7 @@ sciATACseq:
 sciRNAseq:
     description: sciRNA-seq
 seqFish:
-    description: seqFish
+    description: seqFISH
 seqFish_lab_processed:
     description: seqFISH [Lab Processed]
 snATACseq:

--- a/data/schemas/dataset.schema.yaml
+++ b/data/schemas/dataset.schema.yaml
@@ -44,7 +44,11 @@ properties:
     - codex_cytokit
     - image_pyramid
     - salmon_rnaseq_10x
+    - salmon_rnaseq_bulk
+    - salmon_rnaseq_sciseq
+    - salmon_rnaseq_snareseq
     - scRNA-Seq-10x
+    - sc_atac_seq_snare
     - sciATACseq
     - sciRNAseq
     - seqFish


### PR DESCRIPTION
Fixed these mappings:
[sc_atac_seq_snare] = scATAC-seq (SNARE-seq) [SnapATAC]
[salmon_rnaseq_snareseq] = scRNA-seq (SNARE-seq) [Salmon]
[seqFISH_lab_processed] = seqFISH [Lab Processed]
[seqFish] = seqFISH
[salmon_rnaseq_bulk] = Bulk RNA-seq [Salmon]
[salmon_rnaseq_sciseq] = scRNA-seq (sciSeq) [Salmon]

Addresses #23.